### PR TITLE
Fix by tutorial

### DIFF
--- a/cocotbext/fcov/coverage.py
+++ b/cocotbext/fcov/coverage.py
@@ -466,7 +466,7 @@ class CoverGroup:
             if isinstance(cp, Iterable):
                 assert isinstance(v, Iterable), f"Value ({v}) should be Iterable for CoverPoint {k}"
                 assert len(cp) == len(v), f"Length of values ({len(v)}) is not same to CoverPoint {k} ({len(cp)})"
-                for cpi, vi in zip(cp, v):
+                for (_, cpi), vi in zip(cp, v):
                     cpi.value = vi
             else:
                 assert not isinstance(v, Iterable)
@@ -476,7 +476,7 @@ class CoverGroup:
         values = dict()
         for k, v, _ in self._traverse_coverpoint(flatten=False):
             if isinstance(v, Iterable):
-                values[k] = [i.value for i in v]
+                values[k] = [i.value for _, i in v]
             else:
                 values[k] = v.value
         return values

--- a/cocotbext/fcov/make_coverage.py
+++ b/cocotbext/fcov/make_coverage.py
@@ -21,9 +21,13 @@ def get_coverage_models(cov_file):
             if isinstance(value, CoverageModel):
                 coverage_models[attr] = value
             elif isinstance(value, Iterable):
-                model_list = [(i, m) for i, m in enumerate(value) if isinstance(m, CoverageModel)]
-                if model_list:
-                    coverage_models[attr] = model_list
+                try:
+                    model_list = [(i, m) for i, m in enumerate(value) if isinstance(m, CoverageModel)]
+                except TypeError as e:
+                    continue
+                else:
+                    if len(model_list) != 0:
+                        coverage_models[attr] = model_list
     return coverage_models
 
 


### PR DESCRIPTION
### make_coverage 에서 getitem iterable 객체 제외

tutorial 에서 모든 testbench (test, agent, coverage, model .. ) 코드가 하나의 파일에 모아져있어 발견된 버그인데,
getitem method 로 iterable 이 지원되는 경우 list comprehension 은 지원 안되지만
isinstance(value, Iterable) 은 true 로 반환하여 발생된 버그입니다.
예외처리문을 통해 bug fix 하였습니다.

### list 로 선언된 coverpoint 버그

list 로 선언된 coverpoint 객체에서 sampling 을 할 시에 minor 한 버그가 발생하여 수정했습니다.
